### PR TITLE
Adding sample code to demonstrate getter usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ ValueObject v =
         .build();
 
 v = v.withName("Doe");
+
+//fetch values via standard getters
+List<Integer> counts = v.getCounts();
+Optional<String> description = v.getDescription();
 ```
 
 ImmutableValueObject then would not be used outside of generated type. See about this and other generation [styles here](https://immutables.github.io/style.html) 


### PR DESCRIPTION
Demonstrates that the "addCounts" creates a list, and that the description, though an optional, can be set with just a String.